### PR TITLE
restrict Atmel support for Windows.

### DIFF
--- a/mbed_flasher/flashers/FlasherAtmelAt.py
+++ b/mbed_flasher/flashers/FlasherAtmelAt.py
@@ -69,8 +69,6 @@ class FlasherAtmelAt(object):
     def get_available_devices():
         """list available devices
         """
-        if platform.system() != 'Windows':
-            return []
         FlasherAtmelAt.set_atprogram_exe(FlasherAtmelAt.exe)
         cmd = FlasherAtmelAt.exe + " list"
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE )

--- a/mbed_flasher/flashers/__init__.py
+++ b/mbed_flasher/flashers/__init__.py
@@ -1,7 +1,10 @@
+import platform 
 from FlasherMbed import FlasherMbed
 from FlasherAtmelAt import FlasherAtmelAt
 
 AvailableFlashers = [
-    FlasherMbed,
-    FlasherAtmelAt
+    FlasherMbed
 ]
+
+if platform.system() == 'Windows':
+    AvailableFlashers.append(FlasherAtmelAt)


### PR DESCRIPTION
On Linux OS when device list is not given Atmel side code is called, coded to support Windows only.

@jupe 
