### PR TITLE
handle OSError while writing without crashing

### DIFF
--- a/mbed_flasher/flashers/FlasherMbed.py
+++ b/mbed_flasher/flashers/FlasherMbed.py
@@ -207,8 +207,13 @@ class FlasherMbed(object):
                         self.logger.debug("SHA1: %s" % hashlib.sha1(aux_source).hexdigest())
                         self.logger.debug("writing binary: %s (size=%i bytes)", destination, len(aux_source))
                         new_file = os.open(destination, os.O_CREAT | os.O_DIRECT | os.O_TRUNC | os.O_RDWR)
-                        os.write(new_file, aux_source)
-                        os.close(new_file)
+                        try:
+                            os.write(new_file, aux_source)
+                            os.close(new_file)
+                        except OSError as e:
+                            self.logger.error("Write failed due to OSError")
+                            self.logger.error(e)
+                            return -14
                     self.logger.debug("copy finished")
                     sleep(4)
                     

--- a/mbed_flasher/flashers/FlasherMbed.py
+++ b/mbed_flasher/flashers/FlasherMbed.py
@@ -207,13 +207,8 @@ class FlasherMbed(object):
                         self.logger.debug("SHA1: %s" % hashlib.sha1(aux_source).hexdigest())
                         self.logger.debug("writing binary: %s (size=%i bytes)", destination, len(aux_source))
                         new_file = os.open(destination, os.O_CREAT | os.O_DIRECT | os.O_TRUNC | os.O_RDWR)
-                        try:
-                            os.write(new_file, aux_source)
-                            os.close(new_file)
-                        except OSError as e:
-                            self.logger.error("Write failed due to OSError")
-                            self.logger.error(e)
-                            return -14
+                        os.write(new_file, aux_source)
+                        os.close(new_file)
                     self.logger.debug("copy finished")
                     sleep(4)
                     
@@ -257,3 +252,7 @@ class FlasherMbed(object):
                 except IOError as err:
                     self.logger.error(err)
                     raise err
+                except OSError as e:
+                    self.logger.error("Write failed due to OSError")
+                    self.logger.error(e)
+                    return -14

--- a/mbed_flasher/flashers/FlasherMbed.py
+++ b/mbed_flasher/flashers/FlasherMbed.py
@@ -19,7 +19,7 @@ import logging
 import sys
 import six
 from os.path import join, abspath, dirname, isfile
-from shutil import copy
+from shutil import copy2
 import os
 import platform
 from time import sleep
@@ -196,7 +196,8 @@ class FlasherMbed(object):
                             aux_source = f.read()
                             self.logger.debug("SHA1: %s" % hashlib.sha1(aux_source).hexdigest())
                         self.logger.debug("copying file: %s to %s" % (source, destination))
-                        copy(source, destination)
+                        os.system ("copy %s %s" % (source, destination))
+                        #copy2(source, destination)
                     else:
                         self.logger.debug('read source file')
                         with open(source, 'rb') as f:


### PR DESCRIPTION
This fixes issues noticed when flashing is done under Windows. 
Python copy changed to OS copy command call.

@jupe 