### PR TITLE
Remove sleep after copy bin and extend mount point timeout

### DIFF
--- a/mbed_flasher/common.py
+++ b/mbed_flasher/common.py
@@ -45,7 +45,7 @@ class MountVerifier(object):
     Verifier class used to verify that device returns to operational state
     after flash or erase.
     """
-    MOUNT_POINT_TIMEOUT = 20
+    MOUNT_POINT_TIMEOUT = 60
     SERIAL_POINT_TIMEOUT = 20
 
     def __init__(self, logger):

--- a/mbed_flasher/flashers/FlasherMbed.py
+++ b/mbed_flasher/flashers/FlasherMbed.py
@@ -321,7 +321,7 @@ class FlasherMbed(object):
         # check if mount point disappear after file copied into device
         mount_point_previous_mounted = None
 
-        mount_point_disappear_timeout = 20
+        mount_point_disappear_timeout = 30
 
         while mount_point_disappear_timeout > 0:
             if os.path.ismount(mount_point):

--- a/mbed_flasher/flashers/FlasherMbed.py
+++ b/mbed_flasher/flashers/FlasherMbed.py
@@ -160,7 +160,27 @@ class FlasherMbed(object):
                 return EXIT_CODE_FILE_COULD_NOT_BE_READ
 
             self.logger.debug("copy finished")
-            sleep(4)
+
+            def worker(mp):
+                mount_point_previous_mounted = None
+
+                count = 10
+
+                while count > 0:
+                    print os.path.ismount(mp)
+
+                    if os.path.ismount(mp):
+                        mount_point_previous_mounted = True
+
+                    if not os.path.ismount(mp) and mount_point_previous_mounted is True:
+                        break
+
+                    sleep(1)
+                    count -= 1
+
+            t = Thread(target=worker, args=(mount_point,))
+            t.start()
+            t.join()
 
             new_target = MountVerifier(self.logger).check_points_unchanged(target)
 

--- a/mbed_flasher/flashers/FlasherMbed.py
+++ b/mbed_flasher/flashers/FlasherMbed.py
@@ -49,6 +49,7 @@ class FlasherMbed(object):
     """
     name = "mbed"
     FLASHING_VERIFICATION_TIMEOUT = 100
+    MOUNT_POINT_DISAPPEAR_TIMEOUT = 30
 
     def __init__(self, logger=None):
         self.logger = logger if logger else logging.getLogger('mbed-flasher')
@@ -316,9 +317,7 @@ class FlasherMbed(object):
         # check if mount point disappear after file copied into device
         mount_point_previous_mounted = None
 
-        mount_point_disappear_timeout = 30
-
-        while mount_point_disappear_timeout > 0:
+        for _ in range(self.MOUNT_POINT_DISAPPEAR_TIMEOUT):
             if os.path.ismount(mount_point):
                 mount_point_previous_mounted = True
 
@@ -327,7 +326,7 @@ class FlasherMbed(object):
                 return
 
             sleep(1)
-            mount_point_disappear_timeout -= 1
 
-        self.logger.error("After file copied, mount point did not disappear in 20 seconds")
+        self.logger.error("After file copied, mount point did not disappear in %d seconds",
+                          self.MOUNT_POINT_DISAPPEAR_TIMEOUT)
         raise MountPointDisappearTimeoutError

--- a/mbed_flasher/flashers/FlasherMbed.py
+++ b/mbed_flasher/flashers/FlasherMbed.py
@@ -129,7 +129,7 @@ class FlasherMbed(object):
                 self.logger.debug("re-mount check timed out for %s", drive[0])
                 break
 
-    # pylint: disable=too-many-return-statements, duplicate-except
+    # pylint: disable=too-many-return-statements, duplicate-except, too-many-branches, lost-exception
     def flash(self, source, target, method, no_reset):
         """copy file to the destination
         :param source: binary to be flashed
@@ -168,6 +168,9 @@ class FlasherMbed(object):
                 self._check_mount_point_disappear(mount_point)
                 self.logger.info("mount point disappear success")
             except MountPointDisappearTimeoutError as err:
+                # The pylint warnings: lost-exception happens if some error other than the
+                # MountPointDisappearTimeoutError occurs in the above try block, it has chance
+                # to be overwritten by the following finally block raised errors
                 self.logger.error(err)
                 # MountVerifier(self.logger).check_points_unchanged(target)
                 return EXIT_CODE_MOUNT_POINT_DISAPPEAR_TIMEOUT
@@ -193,9 +196,6 @@ class FlasherMbed(object):
             # verify flashing went as planned
             self.logger.debug("verifying flash")
             return self.verify_flash_success(new_target, target, tail)
-        except MountPointDisappearTimeoutError as err:
-            self.logger.error(err)
-            return EXIT_CODE_MOUNT_POINT_DISAPPEAR_TIMEOUT
         except IOError as err:
             self.logger.error(err)
             raise err
@@ -334,6 +334,5 @@ class FlasherMbed(object):
             sleep(1)
             mount_point_disappear_timeout -= 1
 
-        self.logger.error("After file copied, mount point did not disappear in the system in %i seconds",
-                          mount_point_disappear_timeout)
+        self.logger.error("After file copied, mount point did not disappear in 20 seconds")
         raise MountPointDisappearTimeoutError

--- a/mbed_flasher/flashers/MbedFlashError.py
+++ b/mbed_flasher/flashers/MbedFlashError.py
@@ -1,8 +1,19 @@
+"""
+Customized Errors
+"""
+
+
 class MbedFlashError(Exception):
+    """
+    class MbedFlashError can be used as a general error for mbed-flasher
+    """
     def __init__(self, message="MbedFlashError"):
-        super(MbedFlashError, self).__init__(message)
+        Exception.__init__(self, message)
 
 
 class MountPointDisappearTimeoutError(MbedFlashError):
+    """
+    MountPointDisappearTimeoutError
+    """
     def __init__(self, message="MountPointDisappearTimeoutError"):
-        super(MountPointDisappearTimeoutError, self).__init__(message)
+        MbedFlashError.__init__(self, message)

--- a/mbed_flasher/flashers/MbedFlashError.py
+++ b/mbed_flasher/flashers/MbedFlashError.py
@@ -1,0 +1,8 @@
+class MbedFlashError(Exception):
+    def __init__(self, message="MbedFlashError"):
+        super(MbedFlashError, self).__init__(message)
+
+
+class MountPointDisappearTimeoutError(MbedFlashError):
+    def __init__(self, message="MountPointDisappearTimeoutError"):
+        super(MountPointDisappearTimeoutError, self).__init__(message)

--- a/test/test_flash.py
+++ b/test/test_flash.py
@@ -96,10 +96,11 @@ class FlashTestCase(unittest.TestCase):
         self.assertEqual(ret, 55)
 
     # pylint: disable=unused-argument
+    @mock.patch('os.path.ismount')
     @mock.patch('mbed_flasher.flashers.FlasherMbed.FlasherMbed.copy_file')
     @mock.patch('mbed_flasher.common.MountVerifier.check_points_unchanged')
     @mock.patch('mbed_flasher.flashers.FlasherMbed.Popen')
-    def test_run_with_uppercase_HTM(self, mock_popen, mock_verifier, mock_copy_file):
+    def test_run_with_uppercase_HTM(self, mock_popen, mock_verifier, mock_copy_file, mock_is_mount):
         mock_verifier.return_value = {'target_id':'123',
                                       'platform_name': 'K64F',
                                       'mount_point': 'path/'}
@@ -108,6 +109,8 @@ class FlashTestCase(unittest.TestCase):
         mock_out = mock.Mock(side_effect=[b"no-htm", b"test.HTM", b"no-htm"])
         mock_stdout.read = mock_out
         mock_popen.return_value.stdout = mock_stdout
+
+        mock_is_mount.side_effect = [True, True, False, False]
 
         mock_popen.return_value.communicate.return_value = ('', '')
 
@@ -125,10 +128,11 @@ class FlashTestCase(unittest.TestCase):
         self.assertEqual(ret, 0)
         self.assertEqual(2, mock_out.call_count)
 
+    @mock.patch('os.path.ismount')
     @mock.patch('mbed_flasher.flashers.FlasherMbed.FlasherMbed.copy_file')
     @mock.patch('mbed_flasher.common.MountVerifier.check_points_unchanged')
     @mock.patch('mbed_flasher.flashers.FlasherMbed.Popen')
-    def test_run_with_lowercase_HTM(self, mock_popen, mock_verifier, mock_copy_file):
+    def test_run_with_lowercase_HTM(self, mock_popen, mock_verifier, mock_copy_file, mock_is_mount):
         mock_verifier.return_value = {'target_id': '123',
                                       'platform_name': 'K64F',
                                       'mount_point': 'path/'}
@@ -139,6 +143,8 @@ class FlashTestCase(unittest.TestCase):
         mock_popen.return_value.stdout = mock_stdout
 
         mock_popen.return_value.communicate.return_value = ('', '')
+
+        mock_is_mount.side_effect = [True, True, False, False]
 
         flasher = Flash()
         ret = flasher.flash(build=self.bin_path,

--- a/test/test_flash.py
+++ b/test/test_flash.py
@@ -290,7 +290,7 @@ class FlashTestCase(unittest.TestCase):
                 os.system('rm -f %s' % os.path.join(mount_point, 'FAIL.TXT'))
                 os.system('rm %s' % os.path.join(os.getcwd(), fail_bin_path))
 
-            self.assertEqual(ret, 240)
+            self.assertEqual(ret, 3)
         if mock_stdout:
             pass
 

--- a/test/test_flash.py
+++ b/test/test_flash.py
@@ -255,7 +255,7 @@ class FlashTestCase(unittest.TestCase):
             else:
                 os.system('rm %s' % os.path.join(mount_point, 'failing.txt'))
                 os.system('rm %s' % os.path.join(os.getcwd(), fail_txt_path))
-            self.assertEqual(ret, -15)
+            self.assertEqual(ret, 240)
         if mock_stdout:
             pass
 
@@ -290,7 +290,7 @@ class FlashTestCase(unittest.TestCase):
                 os.system('rm -f %s' % os.path.join(mount_point, 'FAIL.TXT'))
                 os.system('rm %s' % os.path.join(os.getcwd(), fail_bin_path))
 
-            self.assertEqual(ret, 3)
+            self.assertEqual(ret, 240)
         if mock_stdout:
             pass
 


### PR DESCRIPTION
## Status
**READY**

## Description
Currently flasher would sleep(4) after copy binay to wait for mount point disapear. And later 20 seconds timeout to wait for mount point re-appear. In total, it's 24 seconds, but now there is 27 seconds needed for some devices.

**Fixes**: IOTSYSTOOL-501

In this PR, 
1. sleep(4) is going to be removed, instead it will check the disappear of mount point, and start immediatly. 
The implementation here set a timeout 30 seconds to wait for mount point disappear. 

2. The MOUNT_POINT_TIMEOUT is increased to 60 seconds. (According to pyclient, the timeout is 60 mins., check [here](https://github.com/ARMmbed/raas-pyclient/blob/209ed3a9aa416db1bbffe663e538b7a315fb1f34/raas_client/resources/Base.py#L35))


## ToDo
- [x] test
  
  