### PR TITLE
Update mbedls

### DIFF
--- a/mbed_flasher/flashers/FlasherST.py
+++ b/mbed_flasher/flashers/FlasherST.py
@@ -72,7 +72,7 @@ class FlasherSTLink(FlasherBase):
         :return: boolean
         """
         try:
-            return target.get("device_type") == FlasherSTLink.name
+            return target["device_type"] == FlasherSTLink.name
         except KeyError:
             return False
 

--- a/mbed_flasher/flashers/FlasherST.py
+++ b/mbed_flasher/flashers/FlasherST.py
@@ -37,14 +37,7 @@ class FlasherSTLink(FlasherBase):
     """
     name = "stlink"
     executable = "ST-LINK_CLI.exe" if sys.platform.startswith("win") else "ST-LINK_CLI"
-    # supported_targets = None
-    # workaround for IOTMORF-2205
-    supported_targets = ["NUCLEO_F401RE",
-                         "NUCLEO_F411RE",
-                         "NUCLEO_F429ZI",
-                         "NUCLEO_L476RG",
-                         "NUCLEO_F767ZI",
-                         "UBLOX_EVK_ODIN_W2"]
+    supported_targets = None
 
     def __init__(self, logger=None):
         FlasherBase.__init__(self, logger)
@@ -79,8 +72,7 @@ class FlasherSTLink(FlasherBase):
         :return: boolean
         """
         try:
-            return target.get("device_type") == FlasherSTLink.name or \
-                target['platform_name'] in FlasherSTLink.supported_targets # IOTMORF-2205
+            return target.get("device_type") == FlasherSTLink.name
         except KeyError:
             return False
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name="mbed-flasher",
           "console_scripts": ["mbedflash=mbed_flasher:mbedflash_main",],
       },
       install_requires=[
-          "mbed-ls==1.4.6",
+          "mbed-ls==1.5.0",
           "six",
           "pyserial",
           "pyOCD"

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name="mbed-flasher",
           "console_scripts": ["mbedflash=mbed_flasher:mbedflash_main",],
       },
       install_requires=[
-          "mbed-ls==1.5.0",
+          "mbed-ls==1.5.1",
           "six",
           "pyserial",
           "pyOCD"

--- a/test/non_hardware/test_flasherstlink.py
+++ b/test/non_hardware/test_flasherstlink.py
@@ -51,7 +51,6 @@ class FlasherSTLinkTest(unittest.TestCase):
     def test_can_flash_when_device_type_matches(self, logger):
         stlink = FlasherSTLink(logger)
         self.assertTrue(stlink.can_flash({"device_type": FlasherSTLink.name}))
-        self.assertTrue(stlink.can_flash({"platform_name": "NUCLEO_F401RE"}))
 
     @mock.patch("mbed_flasher.flash.Logger")
     def test_can_flash_returns_false(self, logger):


### PR DESCRIPTION
## Status
**READY**

## Description
Update mbedls to v1.5.0, which returns stlink device_type for STLink boards. This allows workarounds created for this to be removed.