### PR TITLE
Update pyocd support to version 0.14.0 or later.

### DIFF
--- a/mbed_flasher/reset.py
+++ b/mbed_flasher/reset.py
@@ -1,5 +1,5 @@
 """
-Copyright 2016 ARM Limited
+Copyright 2016,2018 ARM Limited
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -158,17 +158,16 @@ class Reset(object):
         try pyOCD reset
         """
         try:
-            from pyOCD.board import MbedBoard
+            from pyocd.core.helpers import ConnectHelper
         except ImportError:
             raise ResetError(message="pyOCD is not installed",
                              return_code=EXIT_CODE_PYOCD_MISSING)
 
         try:
-            with MbedBoard.chooseBoard(board_id=item["target_id"]) \
-                    as board:
+            with ConnectHelper.session_with_chosen_probe(unique_id=item["target_id"]) \
+                    as session:
                 self.logger.info("resetting device")
-                ocd_target = board.target
-                ocd_target.reset()
+                session.target.reset()
                 self.logger.info("reset completed")
             return EXIT_CODE_SUCCESS
         except AttributeError as err:

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(name="mbed-flasher",
       version=VERSION,
       description=DESCRIPTION,
       long_description=read("README.md"),
+      long_description_content_type='text/markdown',
       author=OWNER_NAMES,
       author_email=OWNER_EMAILS,
       maintainer=OWNER_NAMES,
@@ -56,7 +57,7 @@ setup(name="mbed-flasher",
           "mbed-ls>=1.5.1,==1.*",
           "six",
           "pyserial",
-          "pyOCD!=0.13.0"
+          "pyocd>=0.14.0"
       ],
       classifiers=[
           "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
## Status
**READY**

## Migrations
?

## Description
Brings pyOCD support up to date with version 0.14.0 and later. Also sets the readme MIME content type to Markdown in `setup.py`.

## Todos
- [ ] Tests
- [ ] Documentation


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git pull --prune
git checkout <feature_branch>
python setup.py install
```

1. grunt

## Impacted Areas in Application
- pyOCD usage for reset and flashing