### PR TITLE
Pin python dependencies to an API version, remove pyocd dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,7 @@ setup(name="mbed-flasher",
       install_requires=[
           "mbed-ls>=1.5.1,==1.*",
           "six==1.*",
-          "pyserial==3.*",
-          "pyOCD>=0.13.1,<0.14.0"
+          "pyserial==3.*"
       ],
       classifiers=[
           "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,9 @@ setup(name="mbed-flasher",
       },
       install_requires=[
           "mbed-ls>=1.5.1,==1.*",
-          "six",
-          "pyserial",
-          "pyOCD!=0.13.0"
+          "six==1.*",
+          "pyserial==3.*",
+          "pyOCD>=0.13.1,<0.14.0"
       ],
       classifiers=[
           "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Pin all of the python dependencies to at least the latest major version to ensure stability.

Edit: Also remove pyocd as a dependency. Wherever pyocdis used, the imports are wrapped in try/except blocks and an error code returned. It seems as though it is already an optional dependency, so I'm removing the hard requirement.

## Related PRs
#157 
https://github.com/ARMmbed/icetea/pull/73
https://github.com/ARMmbed/mbed-os-tools/pull/62
https://github.com/ARMmbed/mbed-os/pull/9389

